### PR TITLE
Fixes #150. Pass auth token to romanesco

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -299,7 +299,9 @@
         initialize: function () {
             girder.fetchCurrentUser().success(_.bind(function (user) {
                 if (user) {
-                    girder.currentUser = new girder.models.UserModel(user);
+                    girder.currentUser = new girder.models.UserModel(_.extend(user, {
+                        token: girder.cookie.find('girderToken')
+                    }));
                 }
                 this.render();
             }, this)).error(_.bind(function () {
@@ -474,6 +476,9 @@
         },
 
         login: function () {
+            if (girder.currentUser) {
+                girder.currentUser.set('token', girder.cookie.find('girderToken'));
+            }
             this.render();
             this.collection.fetch({}, true);
         }


### PR DESCRIPTION
This is the minimal change required to fix the bug where private
data could not be downloaded from girder in the romanesco worker.
Many places in the code expected the user model to contain a
"token" field, which it did not. So the easiest thing was just to
set that field on the current user model at startup or login time.

ping @curtislisle @jeffbaumes 