### PR TITLE
Fix an issue where the format key wasn't being passed to analyses

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -355,7 +355,7 @@
             this.datasets.append = true;
             this.datasets.pageLimit = 100;
             this.datasets.on('add', function (item) {
-                item.set(flow.getTypeFormatsFromExtension(_.last(item.get('name').split('.'))));
+                item.set(_.first(flow.getTypeFormatsFromExtension(_.last(item.get('name').split('.')))));
                 item.id = item._id;
                 item.set({collection: flow.collectionForFolder[item.get('folderId')]});
             });


### PR DESCRIPTION
This was accidentally setting the 0 key to be the format/type/validator instead of setting them directly on the object since getTypeFormatsFromExtension returns a list.

@curtislisle 

This might fix the issue but is still a bit sloppy, once tests are functioning this will definitely have to be something that gets tested against.