### PR TITLE
Add libssl-dev and libffi-dev to worker requirements

### DIFF
--- a/devops/ansible/roles/girder_worker-install/tasks/main.yml
+++ b/devops/ansible/roles/girder_worker-install/tasks/main.yml
@@ -10,6 +10,8 @@
     - python-dev
     - python-pip
     - python-virtualenv
+    - libffi-dev
+    - libssl-dev
     - libjpeg-dev
     - zlib1g-dev
   when: do_install|bool


### PR DESCRIPTION
These packages are needed with the addition of `requests[security]` (added in [b0ea26](https://github.com/girder/girder_worker/commit/b0ea2684cc5dd5a382c207caac748d39d1b64b21) of Girder Worker).

@alex-r-bigelow Mind giving this a try from scratch when you get a chance?