### PR TITLE
Fix vagrant provisioning and pin dependencies

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,15 @@
+## This file should be placed in the root directory of your project.
+## Then modify the CMakeLists.txt file in the root directory of your
+## project to incorporate the testing dashboard.
+##
+## # The following are required to submit to the CDash dashboard:
+##   ENABLE_TESTING()
+##   INCLUDE(CTest)
+
+set(CTEST_PROJECT_NAME "Flow")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 EST")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=Flow")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,8 @@ Vagrant.configure(2) do |config|
     }
 
     ansible.extra_vars = {
-      default_user: "vagrant"
+      default_user: "vagrant",
+      flow_version: ENV["FLOW_VERSION"] || `git rev-parse --short HEAD`.delete!("\n")
     }
 
     ansible.playbook = "devops/ansible/site.yml"

--- a/devops/ansible/roles/girder-install/tasks/main.yml
+++ b/devops/ansible/roles/girder-install/tasks/main.yml
@@ -82,13 +82,11 @@
     args:
       chdir: "{{ girder_install_root }}"
 
-
   - name: Install editable version of girder-client
     pip:
       chdir: "{{ girder_install_root }}/clients/python"
-      extra_args: "-e"
+      extra_args: "-Ue"
       name: "."
-
 
   - name: grunt-cli | install
     npm:

--- a/devops/ansible/roles/girder_worker-install/tasks/main.yml
+++ b/devops/ansible/roles/girder_worker-install/tasks/main.yml
@@ -10,6 +10,8 @@
     - python-dev
     - python-pip
     - python-virtualenv
+    - libffi-dev
+    - libssl-dev
     - libjpeg-dev
     - zlib1g-dev
   when: do_install|bool

--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -32,7 +32,7 @@
 
     - role: girder_worker
       rabbitmq_ansible_group: rabbitmq
-      girder_worker_version: "master"
+      girder_worker_version: "965bd45"
       state: started
       sudo: yes
 
@@ -40,7 +40,7 @@
       mongodb_ansible_group: girder
       girder_admin_user: girder
       girder_admin_password: girder
-      girder_version: "master"
+      girder_version: "v1.5.2"
       state: started
       sudo: yes
 


### PR DESCRIPTION
This subsumes #195 in an attempt to get a 100% functioning `vagrant up`.

This PR:
- Fixes breakages
- Makes `vagrant up` provision relative to current git branch
- Pins Girder and Girder Worker to stable versions
- Sets up infrastructure for future testing of Vagrant

### Breakages
Two (unrelated) breakages were noticed late last week with the provisioning scripts.   
1) A new package dependency required a system package (libssl) for Girder Worker 
    This resulted in Girder Worker failing to install the first time Vagrant was provisioned.    
2) A feature in `requests` started getting used that exposed a bug in how we were installing `girder-client` (we were unintentionally using the system-wide version of `requests`). This is what resulted in the issue with `requests` not recognizing the `json` kwarg.

### Provision based on current git revision
Also, this PR changes the Vagrant provisioning to take an optional Flow version. Before, testing PRs required redefining `flow_version` in Ansible to the branch that PR was on (otherwise you would just be testing master). Now the optional Flow version defaults to the revision HEAD is on (so long as this is available remotely this should work).

This PR also resurrects the `CTestConfig.cmake` file to submit builds to CDash. I setup [nightly tests](http://my.cdash.org/index.php?project=Flow&date=) for `vagrant up` against the codebase pinned to specific versions of Girder/Girder Worker and against master branches so we can more easily track down any issues that may arise.