### PR TITLE
Cache R packages with vagrant-cachier

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,9 @@ Vagrant.configure(2) do |config|
     config.cache.scope = :box
     config.cache.enable :apt
     config.cache.enable :npm
+    config.cache.enable :generic, {
+      "R" => { cache_dir: "/usr/local/lib/R" }
+    }
   end
 
   config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
For those using vagrant-cachier this should help.

It turns out downloading the R packages was the slowest part of provisioning, caching these brought my provision time from ~20 minutes to 10.

