### PR TITLE
Stop provisioning VTK by default

### DIFF
--- a/devops/ansible/site.yml
+++ b/devops/ansible/site.yml
@@ -27,9 +27,6 @@
     - role: arbor
       sudo: yes
 
-    - role: vtk
-      sudo: yes
-
     - role: girder_worker
       rabbitmq_ansible_group: rabbitmq
       girder_worker_version: "965bd45"


### PR DESCRIPTION
This steps take a while (and sometimes hangs) and no one is using it so it certainly shouldn't be provisioned by default.