### PR TITLE
Upgrade pip in Girder setup process

### DIFF
--- a/devops/ansible/roles/girder-install/tasks/main.yml
+++ b/devops/ansible/roles/girder-install/tasks/main.yml
@@ -70,6 +70,12 @@
         state: directory
     when: do_install|bool
 
+  - name: Upgrade version of pip
+    pip:
+      extra_args: "--upgrade"
+      name: "pip"
+      virtualenv: "{{venv_root}}"
+
   - name: Install editable version of girder
     pip:
       chdir: "{{ girder_install_root }}"


### PR DESCRIPTION
The version of pip from trusty is 1.5.4 (~2.5 years old), this was failing to properly install CherryPy as they recently added a filename to their repo with unicode characters.

As a silver lining: the nightly builds I setup caught this the night following the new CherryPy release, which made it quite a bit easier to track down.